### PR TITLE
minor update to analyser/tokenizer docs to reflect code changes

### DIFF
--- a/content/docs/Analyzers.md
+++ b/content/docs/Analyzers.md
@@ -18,7 +18,7 @@ The Keyword Analyzer does not perform any analysis on the input text.  It create
 
 The simple analyzer performs only minimal analysis on the input.
 
-* Tokenizer - [Whitespace]({{< relref "docs/Tokenizers.md#whitespace" >}})
+* Tokenizer - [Unicode]({{< relref "docs/Tokenizers.md#unicode" >}})
 * Token Filters
   * [Lowercase]({{< relref "docs/Token-Filters.md#lowercase" >}})
 
@@ -27,7 +27,7 @@ The simple analyzer performs only minimal analysis on the input.
 
 The Standard Analyzer is like the Simple Analyzer but also adds English stop word removal.
 
-* Tokenizer - [Whitespace]({{< relref "docs/Tokenizers.md#whitespace" >}})
+* Tokenizer - [Unicode]({{< relref "docs/Tokenizers.md#unicode" >}})
 * Token Filters
   * [Lowercase]({{< relref "docs/Token-Filters.md#lowercase" >}})
   * English [Stop Token]({{< relref "docs/Token-Filters.md#stop-token" >}})

--- a/content/docs/Tokenizers.md
+++ b/content/docs/Tokenizers.md
@@ -18,7 +18,10 @@ The Regular Expression Tokenizer will tokenize input using a configurable regula
 
 ### Whitespace
 
-The Whitespace Tokenizer is an instance of the Regular Expression Tokenizer.  It uses the regular expression `\w+`.  For many western languages this may work well as a simple tokenizer.
+The Whitespace Tokenizer is an instance of the Regular Expression Tokenizer.  It matches tokens using the regular expression:
+
+    \p{Han}|\p{Hangul}|\p{Hiragana}|\p{Katakana}|[^\p{Z}\p{P}\p{C}\p{Han}\p{Hangul}\p{Hiragana}\p{Katakana}]+
+
 
 ### Unicode
 


### PR DESCRIPTION
A couple of changes in the code which weren't reflected in the docs:
- simple_analyser and standard_analyser now use the "unicode" tokeniser instead of "whitespace".
- The "whitespace" tokenizer now uses a more comprehensive regexp.
