### PR TITLE
Add docs for wildcards in the query string

### DIFF
--- a/content/docs/Query-String-Query.md
+++ b/content/docs/Query-String-Query.md
@@ -49,6 +49,17 @@ You can perform date range searches by using the >, >=, <, and <= operators, fol
 
 Example: `created:>"2016-09-21"` will perform an [Date Range Query]({{< relref "docs/Query.md#date-range" >}}) on the `created` field for values after September 21, 2016.
 
+### Prefix wildcard
+You can perform prefix wildcard queries by adding `*` to the term. This is specially useful for typeahead systems.
+
+Example: `lig*` will perform a [Prefix Query]({{< relref "docs/Query.md#prefix" >}}) matching items that start with `lig`, including       `light`, `lightning` and `ligature`.
+
+You can also use Field Scoping, limiting the results to a specific field, for example: `name:lig*` will match records in where the `name` field starts with `lig`.
+
+`*` will match any sequence of characters.
+
+`?` will match a single character.
+
 ### Escaping
 
 The following quoted string enumerates the characters which may be escaped:


### PR DESCRIPTION
Add docs for wildcards in the query string.

It is already supported and integrated into Couchbase. But it's not documented.

---

The docs for the code are here: https://godoc.org/github.com/blevesearch/bleve#NewWildcardQuery

It is already been tested: https://github.com/blevesearch/bleve/blob/master/search/query/query_string_parser_test.go#L658