### PR TITLE
remove IRC from community page

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -11,10 +11,6 @@ weight = 8
 
 Follow @blevesearch on [twitter](https://twitter.com/blevesearch).
 
-### IRC
-
-Join the #bleve channel on [freenode](https://freenode.net/).
-
 ### Google Group
 
 Discuss use and development of bleve is in [this google group](https://groups.google.com/forum/#!forum/bleve).


### PR DESCRIPTION
amidst all the freenode drama, update our community page
to reflect that we no longer monitor this IRC channel