### PR TITLE
Add a new application: cspapers.org

### DIFF
--- a/content/docs/Applications-using-bleve.md
+++ b/content/docs/Applications-using-bleve.md
@@ -10,6 +10,13 @@ parent = 'userguide'
 
 The following applications use bleve.  Add yours to the list!
 
+## cspapers.org
+
+cspapers.org is a fast and open search engine for Computer Science papers.
+
+* https://cspapers.org
+* https://github.com/swkim101/cspapers.org
+
 ## Caddy
 
 Caddy is an alternative web server that is easy to configure and use.  Caddy uses Bleve to automatically index your site and expose a search page and JSON endpoint.


### PR DESCRIPTION
I'd like to suggest [cspapers.org](https://cspapers.org) as an application using Bleve.   
[cspapers.org](https://cspapers.org) is an academic search engine like Google Scholar, but it supports conference venue filters that Google Scholar poorly supports.   
Also, the source code is fully opened, so it functions as a (bad or good) example of Bleve applications.